### PR TITLE
feat(admin): add tailwind setup

### DIFF
--- a/apps/admin/postcss.config.js
+++ b/apps/admin/postcss.config.js
@@ -1,0 +1,11 @@
+const { join } = require('path');
+
+module.exports = {
+  plugins: [
+    require('postcss-import'),
+    require('tailwindcss')({
+      config: join(__dirname, 'tailwind.config.js'),
+    }),
+    require('autoprefixer'),
+  ],
+};

--- a/apps/admin/src/app/app.tsx
+++ b/apps/admin/src/app/app.tsx
@@ -1,5 +1,4 @@
 import RoutesWrapper from '../Router';
-import '../styles/index.scss';
 import { createTheme } from '@mui/material/styles';
 import 'react-toastify/dist/ReactToastify.css';
 import { ToastContainer } from 'react-toastify';

--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react';
 import * as ReactDOM from 'react-dom/client';
 
 import App from './app/app';
+import './styles.scss';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement

--- a/apps/admin/src/styles.scss
+++ b/apps/admin/src/styles.scss
@@ -1,1 +1,5 @@
-/* You can add global styles to this file, and also import other style files */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@import './styles/index.scss';

--- a/apps/admin/tailwind.config.js
+++ b/apps/admin/tailwind.config.js
@@ -1,0 +1,17 @@
+const defaultTheme = require('tailwindcss/defaultTheme');
+const { join } = require('path');
+
+module.exports = {
+  content: [
+    join(__dirname, 'index.html'),
+    join(__dirname, './src/**/*.{js,ts,jsx,tsx}'),
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['Public Sans', ...defaultTheme.fontFamily.sans],
+      },
+    },
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- set up Tailwind CSS for admin app
- load global Tailwind styles

## Testing
- `npx nx run admin:lint` *(fails: 403 Forbidden - GET https://registry.npmjs.org/nx)*
- `npx nx run admin:test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/nx)*

------
https://chatgpt.com/codex/tasks/task_e_68a6be90570083259d87d752e50bb3d4