### PR TITLE
feat(admin): add organisation details page

### DIFF
--- a/apps/admin/src/Pages/Organisation/Details.tsx
+++ b/apps/admin/src/Pages/Organisation/Details.tsx
@@ -1,0 +1,160 @@
+import { Box, Grid, Typography } from "@mui/material";
+import dayjs from "dayjs";
+import { useParams } from "react-router-dom";
+import { Heading } from "@ethos-frontend/ui";
+import { useRestQuery } from "@ethos-frontend/hook";
+import { API_URL } from "@ethos-frontend/constants";
+import Loading from "../../Components/Loading";
+
+export default function Details() {
+  const { id } = useParams();
+  const { data, isLoading } = useRestQuery<any>(
+    ["org-detail", id],
+    `${API_URL.deleteOrGetOrg}/detail/${id}`
+  );
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  const detailsData = data?.data?.data || {};
+
+  return (
+    <div className="p-4">
+      <Heading variant="h5" className="pb-4">
+        Organisation Details
+      </Heading>
+      <Grid container spacing={2} px={1}>
+        <Grid item md={4} xs={12}>
+          <Box>
+            <Typography variant="subtitle1">Organisation Name</Typography>
+            <Typography variant="h6">{detailsData?.orgName || "-"}</Typography>
+          </Box>
+        </Grid>
+        <Grid item md={4} xs={12}>
+          <Box>
+            <Typography variant="subtitle1">Organisation Number</Typography>
+            <Typography variant="h6">{detailsData?.orgNumber || "-"}</Typography>
+          </Box>
+        </Grid>
+        <Grid item md={4} xs={12}>
+          <Box>
+            <Typography variant="subtitle1">Business Type</Typography>
+            <Typography variant="h6">{detailsData?.businessType || "-"}</Typography>
+          </Box>
+        </Grid>
+        <Grid item md={4} xs={12}>
+          <Box>
+            <Typography variant="subtitle1">Owner Name</Typography>
+            <Typography variant="h6">
+              {detailsData?.ownerFName && detailsData?.ownerLName
+                ? `${detailsData.ownerFName} ${detailsData.ownerLName}`
+                : "-"}
+            </Typography>
+          </Box>
+        </Grid>
+        <Grid item md={4} xs={12}>
+          <Box>
+            <Typography variant="subtitle1">Email</Typography>
+            <Typography variant="h6">{detailsData?.email || "-"}</Typography>
+          </Box>
+        </Grid>
+        <Grid item md={4} xs={12}>
+          <Box>
+            <Typography variant="subtitle1">Phone</Typography>
+            <Typography variant="h6">{detailsData?.phone || "-"}</Typography>
+          </Box>
+        </Grid>
+        <Grid item md={4} xs={12}>
+          <Box>
+            <Typography variant="subtitle1">Home Number</Typography>
+            <Typography variant="h6">{detailsData?.homeNumber || "-"}</Typography>
+          </Box>
+        </Grid>
+        <Grid item md={4} xs={12}>
+          <Box>
+            <Typography variant="subtitle1">Address</Typography>
+            <Typography variant="h6">{detailsData?.address || "-"}</Typography>
+          </Box>
+        </Grid>
+        <Grid item md={4} xs={12}>
+          <Box>
+            <Typography variant="subtitle1">Zipcode</Typography>
+            <Typography variant="h6">{detailsData?.zipcode || "-"}</Typography>
+          </Box>
+        </Grid>
+        <Grid item md={4} xs={12}>
+          <Box>
+            <Typography variant="subtitle1">State</Typography>
+            <Typography variant="h6">{detailsData?.state || "-"}</Typography>
+          </Box>
+        </Grid>
+        <Grid item md={4} xs={12}>
+          <Box>
+            <Typography variant="subtitle1">City</Typography>
+            <Typography variant="h6">{detailsData?.city || "-"}</Typography>
+          </Box>
+        </Grid>
+        <Grid item md={4} xs={12}>
+          <Box>
+            <Typography variant="subtitle1">Country</Typography>
+            <Typography variant="h6">{detailsData?.country || "-"}</Typography>
+          </Box>
+        </Grid>
+        <Grid item md={4} xs={12}>
+          <Box>
+            <Typography variant="subtitle1">Code</Typography>
+            <Typography variant="h6">{detailsData?.code || "-"}</Typography>
+          </Box>
+        </Grid>
+        <Grid item md={4} xs={12}>
+          <Box>
+            <Typography variant="subtitle1">Commission Type</Typography>
+            <Typography variant="h6">{detailsData?.commissionType || "-"}</Typography>
+          </Box>
+        </Grid>
+        <Grid item md={4} xs={12}>
+          <Box>
+            <Typography variant="subtitle1">Commission Value</Typography>
+            <Typography variant="h6">{detailsData?.commissionValue || "-"}</Typography>
+          </Box>
+        </Grid>
+        <Grid item md={4} xs={12}>
+          <Box>
+            <Typography variant="subtitle1">Stripe Connect AcctId</Typography>
+            <Typography variant="h6">
+              {detailsData?.stripeConnectAcctId || "-"}
+            </Typography>
+          </Box>
+        </Grid>
+        <Grid item md={4} xs={12}>
+          <Box>
+            <Typography variant="subtitle1">Stripe Connect Status</Typography>
+            <Typography variant="h6">
+              {detailsData?.stripeConnectStatus || "-"}
+            </Typography>
+          </Box>
+        </Grid>
+        <Grid item md={4} xs={12}>
+          <Box>
+            <Typography variant="subtitle1">Stripe Payout Status</Typography>
+            <Typography variant="h6">
+              {detailsData?.stripePayoutStatus ? "True" : "-"}
+            </Typography>
+          </Box>
+        </Grid>
+        <Grid item md={4} xs={12}>
+          <Box>
+            <Typography variant="subtitle1">Created At</Typography>
+            <Typography variant="h6">
+              {detailsData?.createdAt
+                ? dayjs(detailsData.createdAt).format("MMM DD YYYY")
+                : "-"}
+            </Typography>
+          </Box>
+        </Grid>
+      </Grid>
+    </div>
+  );
+}
+

--- a/apps/admin/src/Pages/Organisation/List.tsx
+++ b/apps/admin/src/Pages/Organisation/List.tsx
@@ -1,4 +1,5 @@
 import { ChangeEvent, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   Table,
   TextField,
@@ -20,9 +21,11 @@ import { Search, MoreVert } from "@mui/icons-material";
 import { useTranslation } from "react-i18next";
 import { useRestMutation, useRestQuery } from "@ethos-frontend/hook";
 import { API_URL } from "@ethos-frontend/constants";
+import { ROUTES } from "../../helpers/constants";
 
 export default function List() {
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const [rows, setRows] = useState<GridRowsProp>([]);
   const [rowCount, setRowCount] = useState(0);
   const [page, setPage] = useState(0);
@@ -123,9 +126,37 @@ export default function List() {
   };
 
   const columns: GridColDef[] = [
-    { field: "orgName", headerName: "Organisation Name", flex: 1 },
+    {
+      field: "orgName",
+      headerName: "Organisation Name",
+      flex: 1,
+      renderCell: (params) => (
+        <span
+          className="cursor-pointer text-blue-600"
+          onClick={() =>
+            navigate(ROUTES.ORG_DETAIL.replace(":id", params.row.id as string))
+          }
+        >
+          {params.row.orgName}
+        </span>
+      ),
+    },
     { field: "name", headerName: "Owner Name", flex: 1 },
-    { field: "orgNumber", headerName: "Organisation Number", flex: 1 },
+    {
+      field: "orgNumber",
+      headerName: "Organisation Number",
+      flex: 1,
+      renderCell: (params) => (
+        <span
+          className="cursor-pointer text-blue-600"
+          onClick={() =>
+            navigate(ROUTES.ORG_DETAIL.replace(":id", params.row.id as string))
+          }
+        >
+          {params.row.orgNumber}
+        </span>
+      ),
+    },
     { field: "email", headerName: "Email", flex: 1, minWidth: 300 },
     { field: "businessType", headerName: "Business Type", flex: 1 },
     { field: "status", headerName: "Status", flex: 1 },

--- a/apps/admin/src/Router/routes.ts
+++ b/apps/admin/src/Router/routes.ts
@@ -3,7 +3,10 @@ import { ROUTES } from "../helpers/constants";
 import { routeTypes } from "../types";
 import Login from "../pages/Login/login";
 
-const Organisation = lazy(() => import("../pages/Organisation"));
+const Organisation = lazy(() => import("../Pages/Organisation"));
+const OrganisationDetails = lazy(
+  () => import("../Pages/Organisation/Details")
+);
 
 export const pageRoutes: routeTypes[] = [
   {
@@ -20,6 +23,14 @@ export const pageRoutes: routeTypes[] = [
     name: "Organisation",
     path: ROUTES.DASHBOARD,
     Component: Organisation,
+    isPrivate: true,
+    pageProp: { page: "organisation" },
+  },
+  {
+    id: 14,
+    name: "Organisation Details",
+    path: ROUTES.ORG_DETAIL,
+    Component: OrganisationDetails,
     isPrivate: true,
     pageProp: { page: "organisation" },
   },

--- a/apps/admin/src/helpers/constants.ts
+++ b/apps/admin/src/helpers/constants.ts
@@ -1,4 +1,5 @@
 export const ROUTES = {
   LOGIN: "/login",
   DASHBOARD: "/",
+  ORG_DETAIL: "/organisation/:id",
 };


### PR DESCRIPTION
## Summary
- add route constant and router entry for organisation detail view
- navigate to detail page when clicking organisation name or number
- new details page shows full organisation information

## Testing
- `pnpm exec nx run admin:lint` *(fails: Command failed with ENOENT: nx run admin:lint)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5f0244388325b2900193d74d163f